### PR TITLE
Push to Two Different Repos on Dockerhub

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -126,8 +126,29 @@ jobs:
               --output type=registry \
               --build-arg RONDB_VERSION=$RONDB_VERSION_LTS \
               --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \
-              --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_LTS-linux-glibc2.35-arm64_v8.tar.gz
-      
+              --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_LTS-linux-glibc2.35-arm64_v8.tar.gz \
+              --cache-to type=registry,ref=hopsworks/rondb-standalone-cache,mode=max \
+              --cache-from type=registry,ref=hopsworks/rondb-standalone-cache,mode=max
+
+  build-and-push-ARM64-two:
+    runs-on: ubuntu-latest
+    # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+    needs: [build-and-push-ARM64]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
+        with:
+          username: hopsworks
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push ARM64 image for RONDB_VERSION_STABLE
         run: |
           docker buildx build . \
@@ -137,4 +158,6 @@ jobs:
               --output type=registry \
               --build-arg RONDB_VERSION=$RONDB_VERSION_STABLE \
               --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \
-              --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.35-arm64_v8.tar.gz
+              --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.35-arm64_v8.tar.gz \
+              --cache-to type=registry,ref=hopsworks/rondb-standalone-cache,mode=max \
+              --cache-from type=registry,ref=hopsworks/rondb-standalone-cache,mode=max

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -9,92 +9,96 @@ on:
 env:
   RONDB_VERSION_LTS: 21.04.10
   RONDB_VERSION_STABLE: 22.10.1
+  ARM_IMAGE_NAME: rondb-standalone-arm64
+  AMD_IMAGE_NAME: rondb-standalone-amd64
+  # ARM_CACHE_IMAGE_NAME: rondb-standalone-cache-arm64
+  # AMD_CACHE_IMAGE_NAME: rondb-standalone-cache-amd64
 
 jobs:
-  # integration-test-and-package:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
+  integration-test-and-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-  #     - name: Build and run Docker Compose cluster with benchmarking for RONDB_VERSION_LTS
-  #       run: |
-  #         ./build_run_docker.sh \
-  #           --rondb-tarball-uri https://repo.hops.works/master/rondb-$RONDB_VERSION_LTS-linux-glibc2.17-x86_64.tar.gz \
-  #           --rondb-version $RONDB_VERSION_LTS \
-  #           --num-mgm-nodes 1 \
-  #           --node-groups 1 \
-  #           --replication-factor 1 \
-  #           --num-mysql-nodes 1 \
-  #           --num-api-nodes 1 \
-  #           --run-benchmark sysbench_single \
-  #           --detached
+      - name: Build and run Docker Compose cluster with benchmarking for RONDB_VERSION_LTS
+        run: |
+          ./build_run_docker.sh \
+            --rondb-tarball-uri https://repo.hops.works/master/rondb-$RONDB_VERSION_LTS-linux-glibc2.17-x86_64.tar.gz \
+            --rondb-version $RONDB_VERSION_LTS \
+            --num-mgm-nodes 1 \
+            --node-groups 1 \
+            --replication-factor 1 \
+            --num-mysql-nodes 1 \
+            --num-api-nodes 1 \
+            --run-benchmark sysbench_single \
+            --detached
 
-  #     - name: Wait for one container exit or timeout
-  #       run: |
-  #         start=`date +%s`
-  #         while true; do
-  #             end=`date +%s`
-  #             runtime=$((end-start))
-  #             if [ $( docker container ls --filter "status=exited" | grep rondb | wc -l ) -gt 0 ]; then
-  #                 echo "One container is down. We can continue"
-  #                 docker container ls --filter "status=exited"
-  #                 exit 0
-  #             elif [ $runtime -gt 800 ]; then
-  #                 echo "The benchmarking seems to be stuck. We're aborting now."
-  #                 docker ps
-  #                 exit 1
-  #             fi
-  #             sleep 2
-  #         done
+      - name: Wait for one container exit or timeout
+        run: |
+          start=`date +%s`
+          while true; do
+              end=`date +%s`
+              runtime=$((end-start))
+              if [ $( docker container ls --filter "status=exited" | grep rondb | wc -l ) -gt 0 ]; then
+                  echo "One container is down. We can continue"
+                  docker container ls --filter "status=exited"
+                  exit 0
+              elif [ $runtime -gt 800 ]; then
+                  echo "The benchmarking seems to be stuck. We're aborting now."
+                  docker ps
+                  exit 1
+              fi
+              sleep 2
+          done
 
-  #     - run: docker container ls
-  #     - run: docker logs mgmd_1
-  #     - run: docker logs ndbd_1
-  #     - run: docker logs mysqld_1
-  #     - run: docker logs api_1
+      - run: docker container ls
+      - run: docker logs mgmd_1
+      - run: docker logs ndbd_1
+      - run: docker logs mysqld_1
+      - run: docker logs api_1
 
-  #     # At this point we only know that one container has exited. We want to
-  #     # check whether the API container has exited with exit code 0. We need
-  #     # both status and exit code to do so, since docker reports exit code 0
-  #     # for running containers.
-  #     - name: Check API Exit Code
-  #       run: |
-  #         if [ "$(docker inspect api_1 --format='{{.State.Status}}')" != "exited" ]
-  #         then
-  #           echo "Some container other than api_1 exited unexpectedly."
-  #           docker ps -a
-  #           exit 1
-  #         elif [ "$(docker inspect api_1 --format='{{.State.ExitCode}}')" != "0" ]
-  #         then
-  #           echo "Benchmarking failed."
-  #           exit 1
-  #         fi
+      # At this point we only know that one container has exited. We want to
+      # check whether the API container has exited with exit code 0. We need
+      # both status and exit code to do so, since docker reports exit code 0
+      # for running containers.
+      - name: Check API Exit Code
+        run: |
+          if [ "$(docker inspect api_1 --format='{{.State.Status}}')" != "exited" ]
+          then
+            echo "Some container other than api_1 exited unexpectedly."
+            docker ps -a
+            exit 1
+          elif [ "$(docker inspect api_1 --format='{{.State.ExitCode}}')" != "0" ]
+          then
+            echo "Benchmarking failed."
+            exit 1
+          fi
 
-  #     - name: Login to Dockerhub
-  #       uses: docker/login-action@v2
-  #       if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-  #       with:
-  #         username: hopsworks
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
+        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        with:
+          username: hopsworks
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Build AMD64 image for RONDB_VERSION_STABLE
-  #       if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-  #       run: |
-  #         docker buildx build . \
-  #             --tag rondb-standalone:$RONDB_VERSION_STABLE \
-  #             --build-arg RONDB_VERSION=$RONDB_VERSION_STABLE \
-  #             --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \
-  #             --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.17-x86_64.tar.gz
-      
-  #     - name: Push AMD64 images to Dockerhub
-  #       if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-  #       run: |
-  #         docker tag rondb-standalone:$RONDB_VERSION_LTS hopsworks/rondb-standalone:$RONDB_VERSION_LTS
-  #         docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/rondb-standalone:$RONDB_VERSION_STABLE
-  #         docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/rondb-standalone:latest
-  #         docker push hopsworks/rondb-standalone:$RONDB_VERSION_LTS
-  #         docker push hopsworks/rondb-standalone:$RONDB_VERSION_STABLE
-  #         docker push hopsworks/rondb-standalone:latest
+      - name: Build AMD64 image for RONDB_VERSION_STABLE
+        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        run: |
+          docker buildx build . \
+              --tag rondb-standalone:$RONDB_VERSION_STABLE \
+              --build-arg RONDB_VERSION=$RONDB_VERSION_STABLE \
+              --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \
+              --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.17-x86_64.tar.gz
+
+      - name: Push AMD64 images to Dockerhub
+        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        run: |
+          docker tag rondb-standalone:$RONDB_VERSION_LTS hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS
+          docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE
+          docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/$AMD_IMAGE_NAME:latest
+          docker push hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS
+          docker push hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE
+          docker push hopsworks/$AMD_IMAGE_NAME:latest
 
   build-and-push-ARM64:
     runs-on: ubuntu-latest
@@ -121,7 +125,7 @@ jobs:
       - name: Build and push ARM64 image for RONDB_VERSION_LTS
         run: |
           docker buildx build . \
-              --tag hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
+              --tag hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_LTS \
               --platform=linux/arm64 \
               --output type=registry \
               --build-arg RONDB_VERSION=$RONDB_VERSION_LTS \
@@ -130,30 +134,11 @@ jobs:
               --cache-to type=registry,ref=hopsworks/rondb-standalone-cache,mode=max \
               --cache-from type=registry,ref=hopsworks/rondb-standalone-cache,mode=max
 
-  build-and-push-ARM64-two:
-    runs-on: ubuntu-latest
-    # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-    needs: [build-and-push-ARM64]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to Dockerhub
-        uses: docker/login-action@v2
-        with:
-          username: hopsworks
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build and push ARM64 image for RONDB_VERSION_STABLE
         run: |
           docker buildx build . \
-              --tag hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
-              --tag hopsworks/rondb-standalone:latest \
+              --tag hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_STABLE \
+              --tag hopsworks/$ARM_IMAGE_NAME:latest \
               --platform=linux/arm64 \
               --output type=registry \
               --build-arg RONDB_VERSION=$RONDB_VERSION_STABLE \
@@ -161,3 +146,34 @@ jobs:
               --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.35-arm64_v8.tar.gz \
               --cache-to type=registry,ref=hopsworks/rondb-standalone-cache,mode=max \
               --cache-from type=registry,ref=hopsworks/rondb-standalone-cache,mode=max
+
+  create-manifests:
+    runs-on: ubuntu-latest
+    # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+    # needs: [build-and-push-ARM64]
+    steps:
+      - name: Create multi-platform manifest for RONDB_VERSION_LTS
+        run: |
+          docker manifest create hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
+            hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_LTS \
+            hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS
+
+          docker manifest annotate hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
+              hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_LTS --arch arm64
+          docker manifest annotate hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
+              hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS --arch amd64
+
+          docker manifest push hopsworks/rondb-standalone:$RONDB_VERSION_LTS
+
+      - name: Create multi-platform manifest for RONDB_VERSION_STABLE
+        run: |
+          docker manifest create hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
+            hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_STABLE \
+            hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE
+
+          docker manifest annotate hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
+              hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_STABLE --arch arm64
+          docker manifest annotate hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
+              hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE --arch amd64
+
+          docker manifest push hopsworks/rondb-standalone:$RONDB_VERSION_STABLE

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -143,3 +143,28 @@ jobs:
               --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.35-arm64_v8.tar.gz \
               --cache-to type=registry,ref=hopsworks/rondb-standalone-cache,mode=max \
               --cache-from type=registry,ref=hopsworks/rondb-standalone-cache,mode=max
+
+  build-and-push-cross-platform-image:
+    runs-on: ubuntu-latest
+    # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
+        with:
+          username: hopsworks
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-platform image
+        run: |
+          docker buildx imagetools create -t hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
+            hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS \
+            hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_LTS
+          docker buildx imagetools create -t hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
+            hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE \
+            hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_STABLE
+          docker buildx imagetools create -t hopsworks/rondb-standalone:latest \
+            hopsworks/$AMD_IMAGE_NAME:latest \
+            hopsworks/$ARM_IMAGE_NAME:latest

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -74,13 +74,13 @@ jobs:
 
       - name: Login to Dockerhub
         uses: docker/login-action@v2
-        # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
         with:
           username: hopsworks
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build AMD64 image for RONDB_VERSION_STABLE
-        # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
         run: |
           docker buildx build . \
               --tag rondb-standalone:$RONDB_VERSION_STABLE \
@@ -89,7 +89,7 @@ jobs:
               --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.17-x86_64.tar.gz
 
       - name: Push AMD64 images to Dockerhub
-        # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
         run: |
           docker tag rondb-standalone:$RONDB_VERSION_LTS hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS
           docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE
@@ -100,7 +100,7 @@ jobs:
 
   build-and-push-ARM64:
     runs-on: ubuntu-latest
-    # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+    if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
     steps:
       - uses: actions/checkout@v3
 
@@ -146,7 +146,7 @@ jobs:
 
   build-and-push-cross-platform-image:
     runs-on: ubuntu-latest
-    # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+    if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
     needs: [integration-test-and-package, build-and-push-ARM64]
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -11,8 +11,6 @@ env:
   RONDB_VERSION_STABLE: 22.10.1
   ARM_IMAGE_NAME: rondb-standalone-arm64
   AMD_IMAGE_NAME: rondb-standalone-amd64
-  # ARM_CACHE_IMAGE_NAME: rondb-standalone-cache-arm64
-  # AMD_CACHE_IMAGE_NAME: rondb-standalone-cache-amd64
 
 jobs:
   integration-test-and-package:
@@ -145,40 +143,3 @@ jobs:
               --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.35-arm64_v8.tar.gz \
               --cache-to type=registry,ref=hopsworks/rondb-standalone-cache,mode=max \
               --cache-from type=registry,ref=hopsworks/rondb-standalone-cache,mode=max
-
-  create-manifests:
-    runs-on: ubuntu-latest
-    # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-    needs: [integration-test-and-package, build-and-push-ARM64]
-    steps:
-      - name: Login to Dockerhub
-        uses: docker/login-action@v2
-        with:
-          username: hopsworks
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Create multi-platform manifest for RONDB_VERSION_LTS
-        run: |
-          docker manifest create hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
-            hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_LTS \
-            hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS
-
-          docker manifest annotate hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
-              hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_LTS --arch arm64
-          docker manifest annotate hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
-              hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS --arch amd64
-
-          docker manifest push hopsworks/rondb-standalone:$RONDB_VERSION_LTS
-
-      - name: Create multi-platform manifest for RONDB_VERSION_STABLE
-        run: |
-          docker manifest create hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
-            hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_STABLE \
-            hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE
-
-          docker manifest annotate hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
-              hopsworks/$ARM_IMAGE_NAME:$RONDB_VERSION_STABLE --arch arm64
-          docker manifest annotate hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
-              hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE --arch amd64
-
-          docker manifest push hopsworks/rondb-standalone:$RONDB_VERSION_STABLE

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -76,13 +76,13 @@ jobs:
 
       - name: Login to Dockerhub
         uses: docker/login-action@v2
-        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
         with:
           username: hopsworks
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build AMD64 image for RONDB_VERSION_STABLE
-        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
         run: |
           docker buildx build . \
               --tag rondb-standalone:$RONDB_VERSION_STABLE \
@@ -91,7 +91,7 @@ jobs:
               --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.17-x86_64.tar.gz
 
       - name: Push AMD64 images to Dockerhub
-        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+        # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
         run: |
           docker tag rondb-standalone:$RONDB_VERSION_LTS hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_LTS
           docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/$AMD_IMAGE_NAME:$RONDB_VERSION_STABLE
@@ -103,7 +103,6 @@ jobs:
   build-and-push-ARM64:
     runs-on: ubuntu-latest
     # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-    # needs: [integration-test-and-package]
     steps:
       - uses: actions/checkout@v3
 
@@ -150,7 +149,7 @@ jobs:
   create-manifests:
     runs-on: ubuntu-latest
     # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-    needs: [build-and-push-ARM64]
+    needs: [integration-test-and-package, build-and-push-ARM64]
     steps:
       - name: Login to Dockerhub
         uses: docker/login-action@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -152,6 +152,12 @@ jobs:
     # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
     # needs: [build-and-push-ARM64]
     steps:
+      - name: Login to Dockerhub
+        uses: docker/login-action@v2
+        with:
+          username: hopsworks
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Create multi-platform manifest for RONDB_VERSION_LTS
         run: |
           docker manifest create hopsworks/rondb-standalone:$RONDB_VERSION_LTS \

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -150,7 +150,7 @@ jobs:
   create-manifests:
     runs-on: ubuntu-latest
     # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-    # needs: [build-and-push-ARM64]
+    needs: [build-and-push-ARM64]
     steps:
       - name: Login to Dockerhub
         uses: docker/login-action@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -118,29 +118,23 @@ jobs:
       # We're skipping the benchmarking on ARM64 as we assume this will be run on a regular basis
       # during development. ARM64 images are only for development anyways. It is more important to add
       # all types of benchmarking to the tests.
-      - name: Build ARM64 image for RONDB_VERSION_LTS
+      - name: Build and push ARM64 image for RONDB_VERSION_LTS
         run: |
           docker buildx build . \
-              --tag rondb-standalone:$RONDB_VERSION_LTS \
+              --tag hopsworks/rondb-standalone:$RONDB_VERSION_LTS \
               --platform=linux/arm64 \
+              --output type=registry \
               --build-arg RONDB_VERSION=$RONDB_VERSION_LTS \
               --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \
               --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_LTS-linux-glibc2.35-arm64_v8.tar.gz
       
-      - name: Build ARM64 image for RONDB_VERSION_STABLE
+      - name: Build and push ARM64 image for RONDB_VERSION_STABLE
         run: |
           docker buildx build . \
-              --tag rondb-standalone:$RONDB_VERSION_STABLE \
+              --tag hopsworks/rondb-standalone:$RONDB_VERSION_STABLE \
+              --tag hopsworks/rondb-standalone:latest \
               --platform=linux/arm64 \
+              --output type=registry \
               --build-arg RONDB_VERSION=$RONDB_VERSION_STABLE \
               --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \
               --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.35-arm64_v8.tar.gz
-      
-      - name: Push ARM64 images to Dockerhub
-        run: |
-          docker tag rondb-standalone:$RONDB_VERSION_LTS hopsworks/rondb-standalone:$RONDB_VERSION_LTS
-          docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/rondb-standalone:$RONDB_VERSION_STABLE
-          docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/rondb-standalone:latest
-          docker push hopsworks/rondb-standalone:$RONDB_VERSION_LTS
-          docker push hopsworks/rondb-standalone:$RONDB_VERSION_STABLE
-          docker push hopsworks/rondb-standalone:latest

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -11,95 +11,95 @@ env:
   RONDB_VERSION_STABLE: 22.10.1
 
 jobs:
-  integration-test-and-package:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+  # integration-test-and-package:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: Build and run Docker Compose cluster with benchmarking for RONDB_VERSION_LTS
-        run: |
-          ./build_run_docker.sh \
-            --rondb-tarball-uri https://repo.hops.works/master/rondb-$RONDB_VERSION_LTS-linux-glibc2.17-x86_64.tar.gz \
-            --rondb-version $RONDB_VERSION_LTS \
-            --num-mgm-nodes 1 \
-            --node-groups 1 \
-            --replication-factor 1 \
-            --num-mysql-nodes 1 \
-            --num-api-nodes 1 \
-            --run-benchmark sysbench_single \
-            --detached
+  #     - name: Build and run Docker Compose cluster with benchmarking for RONDB_VERSION_LTS
+  #       run: |
+  #         ./build_run_docker.sh \
+  #           --rondb-tarball-uri https://repo.hops.works/master/rondb-$RONDB_VERSION_LTS-linux-glibc2.17-x86_64.tar.gz \
+  #           --rondb-version $RONDB_VERSION_LTS \
+  #           --num-mgm-nodes 1 \
+  #           --node-groups 1 \
+  #           --replication-factor 1 \
+  #           --num-mysql-nodes 1 \
+  #           --num-api-nodes 1 \
+  #           --run-benchmark sysbench_single \
+  #           --detached
 
-      - name: Wait for one container exit or timeout
-        run: |
-          start=`date +%s`
-          while true; do
-              end=`date +%s`
-              runtime=$((end-start))
-              if [ $( docker container ls --filter "status=exited" | grep rondb | wc -l ) -gt 0 ]; then
-                  echo "One container is down. We can continue"
-                  docker container ls --filter "status=exited"
-                  exit 0
-              elif [ $runtime -gt 800 ]; then
-                  echo "The benchmarking seems to be stuck. We're aborting now."
-                  docker ps
-                  exit 1
-              fi
-              sleep 2
-          done
+  #     - name: Wait for one container exit or timeout
+  #       run: |
+  #         start=`date +%s`
+  #         while true; do
+  #             end=`date +%s`
+  #             runtime=$((end-start))
+  #             if [ $( docker container ls --filter "status=exited" | grep rondb | wc -l ) -gt 0 ]; then
+  #                 echo "One container is down. We can continue"
+  #                 docker container ls --filter "status=exited"
+  #                 exit 0
+  #             elif [ $runtime -gt 800 ]; then
+  #                 echo "The benchmarking seems to be stuck. We're aborting now."
+  #                 docker ps
+  #                 exit 1
+  #             fi
+  #             sleep 2
+  #         done
 
-      - run: docker container ls
-      - run: docker logs mgmd_1
-      - run: docker logs ndbd_1
-      - run: docker logs mysqld_1
-      - run: docker logs api_1
+  #     - run: docker container ls
+  #     - run: docker logs mgmd_1
+  #     - run: docker logs ndbd_1
+  #     - run: docker logs mysqld_1
+  #     - run: docker logs api_1
 
-      # At this point we only know that one container has exited. We want to
-      # check whether the API container has exited with exit code 0. We need
-      # both status and exit code to do so, since docker reports exit code 0
-      # for running containers.
-      - name: Check API Exit Code
-        run: |
-          if [ "$(docker inspect api_1 --format='{{.State.Status}}')" != "exited" ]
-          then
-            echo "Some container other than api_1 exited unexpectedly."
-            docker ps -a
-            exit 1
-          elif [ "$(docker inspect api_1 --format='{{.State.ExitCode}}')" != "0" ]
-          then
-            echo "Benchmarking failed."
-            exit 1
-          fi
+  #     # At this point we only know that one container has exited. We want to
+  #     # check whether the API container has exited with exit code 0. We need
+  #     # both status and exit code to do so, since docker reports exit code 0
+  #     # for running containers.
+  #     - name: Check API Exit Code
+  #       run: |
+  #         if [ "$(docker inspect api_1 --format='{{.State.Status}}')" != "exited" ]
+  #         then
+  #           echo "Some container other than api_1 exited unexpectedly."
+  #           docker ps -a
+  #           exit 1
+  #         elif [ "$(docker inspect api_1 --format='{{.State.ExitCode}}')" != "0" ]
+  #         then
+  #           echo "Benchmarking failed."
+  #           exit 1
+  #         fi
 
-      - name: Login to Dockerhub
-        uses: docker/login-action@v2
-        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-        with:
-          username: hopsworks
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Login to Dockerhub
+  #       uses: docker/login-action@v2
+  #       if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+  #       with:
+  #         username: hopsworks
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build AMD64 image for RONDB_VERSION_STABLE
-        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-        run: |
-          docker buildx build . \
-              --tag rondb-standalone:$RONDB_VERSION_STABLE \
-              --build-arg RONDB_VERSION=$RONDB_VERSION_STABLE \
-              --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \
-              --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.17-x86_64.tar.gz
+  #     - name: Build AMD64 image for RONDB_VERSION_STABLE
+  #       if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+  #       run: |
+  #         docker buildx build . \
+  #             --tag rondb-standalone:$RONDB_VERSION_STABLE \
+  #             --build-arg RONDB_VERSION=$RONDB_VERSION_STABLE \
+  #             --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \
+  #             --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-$RONDB_VERSION_STABLE-linux-glibc2.17-x86_64.tar.gz
       
-      - name: Push AMD64 images to Dockerhub
-        if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-        run: |
-          docker tag rondb-standalone:$RONDB_VERSION_LTS hopsworks/rondb-standalone:$RONDB_VERSION_LTS
-          docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/rondb-standalone:$RONDB_VERSION_STABLE
-          docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/rondb-standalone:latest
-          docker push hopsworks/rondb-standalone:$RONDB_VERSION_LTS
-          docker push hopsworks/rondb-standalone:$RONDB_VERSION_STABLE
-          docker push hopsworks/rondb-standalone:latest
+  #     - name: Push AMD64 images to Dockerhub
+  #       if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+  #       run: |
+  #         docker tag rondb-standalone:$RONDB_VERSION_LTS hopsworks/rondb-standalone:$RONDB_VERSION_LTS
+  #         docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/rondb-standalone:$RONDB_VERSION_STABLE
+  #         docker tag rondb-standalone:$RONDB_VERSION_STABLE hopsworks/rondb-standalone:latest
+  #         docker push hopsworks/rondb-standalone:$RONDB_VERSION_LTS
+  #         docker push hopsworks/rondb-standalone:$RONDB_VERSION_STABLE
+  #         docker push hopsworks/rondb-standalone:latest
 
   build-and-push-ARM64:
     runs-on: ubuntu-latest
-    if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
-    needs: [integration-test-and-package]
+    # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+    # needs: [integration-test-and-package]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -147,6 +147,7 @@ jobs:
   build-and-push-cross-platform-image:
     runs-on: ubuntu-latest
     # if: github.repository == 'logicalclocks/rondb-docker' && github.ref_name == 'main'
+    needs: [integration-test-and-package, build-and-push-ARM64]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ ARG OPEN_SSL_VERSION=1.1.1s
 RUN echo "Running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 RUN echo "TARGETARCH: $TARGETARCH; TARGETVARIANT: $TARGETVARIANT"
 
-RUN --mount=type=cache,target=/var/cache/apt,id=ubuntu22-apt \
-    --mount=type=cache,target=/var/lib/apt/lists,id=ubuntu22-apt-lists \
+RUN --mount=type=cache,target=/var/cache/apt,id=ubuntu22-apt-$TARGETPLATFORM \
+    --mount=type=cache,target=/var/lib/apt/lists,id=ubuntu22-apt-lists-$TARGETPLATFORM \
     apt-get update -y \
     && apt-get install -y wget tar gzip \
     libaio1 libaio-dev \
@@ -46,8 +46,8 @@ RUN mkdir $DOWNLOADS_CACHE_DIR
 #   commands are from https://linuxpip.org/install-openssl-linux/
 ENV OPENSSL_ROOT=/usr/local/ssl
 RUN --mount=type=cache,target=$DOWNLOADS_CACHE_DIR \
-    --mount=type=cache,target=/var/cache/apt,id=ubuntu22-apt \
-    --mount=type=cache,target=/var/lib/apt/lists,id=ubuntu22-apt-lists \
+    --mount=type=cache,target=/var/cache/apt,id=ubuntu22-apt-$TARGETPLATFORM \
+    --mount=type=cache,target=/var/lib/apt/lists,id=ubuntu22-apt-lists-$TARGETPLATFORM \
     apt-get update -y \
     && apt-get install -y build-essential checkinstall zlib1g-dev \
     && wget -N --progress=bar:force -P $DOWNLOADS_CACHE_DIR \


### PR DESCRIPTION
Previously, the ARM64 images would replace the AMD64 images because they weren't defined as multi-platform images.

Done:
* Bind the ARM64 & AMD64 images into single multi-platform images
* Also add remote caches to ARM64 builds; uploaded to Dockerhub
* Add TARGETPLATFORM to cache ids in Dockerfile