### PR TITLE
RONDB-236: Give Access To MySQL User

### DIFF
--- a/resources/entrypoints/init_scripts/access_rights.sql
+++ b/resources/entrypoints/init_scripts/access_rights.sql
@@ -1,0 +1,1 @@
+GRANT ALL PRIVILEGES ON *.* TO 'mysql' @'%';

--- a/resources/entrypoints/init_scripts/setup_ycsb.sql
+++ b/resources/entrypoints/init_scripts/setup_ycsb.sql
@@ -1,0 +1,4 @@
+CREATE TABLE ycsb.usertable (
+    YCSB_KEY VARCHAR(255) PRIMARY KEY,
+    FIELD0 varbinary(4096)
+);

--- a/resources/entrypoints/mysqld.sh
+++ b/resources/entrypoints/mysqld.sh
@@ -135,12 +135,12 @@ DUMMY_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD
 
 # Benchmarking table; all other tables will be created by the benchmakrs themselves
 echo "CREATE DATABASE IF NOT EXISTS \`dbt2\` ;" | mysql
+echo "CREATE DATABASE IF NOT EXISTS \`ycsb\` ;" | mysql
 
 # shellcheck disable=SC2153
 if [ "$MYSQL_USER" ]; then
     echo "[entrypoints/mysqld.sh] Running this command now:"
     echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;"
-
     echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" | mysql
 
     # TODO: Consider placing into docker-entrypoint-initdb.d
@@ -149,12 +149,12 @@ if [ "$MYSQL_USER" ]; then
     echo "GRANT ALL PRIVILEGES ON \`sysbench%\`.* TO '$MYSQL_USER'@'%' ;" | mysql
     echo "GRANT ALL PRIVILEGES ON \`dbt%\`.* TO '$MYSQL_USER'@'%' ;" | mysql
     echo "GRANT ALL PRIVILEGES ON \`sbtest%\`.* TO '$MYSQL_USER'@'%' ;" | mysql
+    echo "GRANT ALL PRIVILEGES ON \`ycsb%\`.* TO '$MYSQL_USER'@'%' ;" | mysql
 else
     echo '[entrypoints/mysqld.sh] Not creating custom user. MYSQL_USER and MYSQL_PASSWORD must be specified to do so.'
 fi
 
-# TODO: Mount this via Docker
-for f in /docker-entrypoint-initdb.d/*; do
+for f in ./docker_entrypoints/rondb_standalone/init_scripts/*; do
     case "$f" in
     *.sh)
         echo "[entrypoints/mysqld.sh] running $f"
@@ -162,7 +162,7 @@ for f in /docker-entrypoint-initdb.d/*; do
         ;;
     *.sql)
         echo "[entrypoints/mysqld.sh] running $f"
-        "${mysql[@]}" <"$f" && echo
+        cat $f | mysql
         ;;
     *) echo "[entrypoints/mysqld.sh] ignoring $f" ;;
     esac


### PR DESCRIPTION
The MySQL user needs access from any container if we want to be able to run the REST API server from a development container. This PR also adds a database & table for ycsb benchmarking.