### PR TITLE
RONDB-365: Bump RonDB 21.04 from .12 to .13

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 env:
-  RONDB_VERSION_LTS: 21.04.12
+  RONDB_VERSION_LTS: 21.04.13
   RONDB_VERSION_STABLE: 22.10.1
   ARM_IMAGE_NAME: rondb-standalone-arm64
   AMD_IMAGE_NAME: rondb-standalone-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN ldconfig --verbose
 
 # Copying bare minimum of Hopsworks cloud environment for now
 FROM rondb_runtime_dependencies as cloud_preparation
-ARG RONDB_VERSION=21.04.12
+ARG RONDB_VERSION=21.04.13
 RUN groupadd mysql && adduser mysql --ingroup mysql
 ENV HOPSWORK_DIR=/srv/hops
 ENV RONDB_BIN_DIR=$HOPSWORK_DIR/mysql-$RONDB_VERSION

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Commands to run:
 # Build and run image **for local platform** in docker-compose using local RonDB tarball (download it first!)
 # Beware that the local platform is linux/arm64 in this case
 ./build_run_docker.sh \
-  --rondb-tarball-path ./rondb-21.04.12-linux-glibc2.35-arm64_v8.tar.gz \
-  --rondb-version 21.04.12 \
+  --rondb-tarball-path ./rondb-21.04.13-linux-glibc2.35-arm64_v8.tar.gz \
+  --rondb-version 21.04.13 \
   --num-mgm-nodes 1 \
   --node-groups 1 \
   --replication-factor 2 \
@@ -101,13 +101,13 @@ Commands to run:
   --num-benchmarking-nodes 1
 
 # Build cross-platform image (linux/arm64 here)
-docker buildx build . --platform=linux/arm64 -t rondb-standalone:21.04.12 \
-  --build-arg RONDB_VERSION=21.04.12 \
+docker buildx build . --platform=linux/arm64 -t rondb-standalone:21.04.13 \
+  --build-arg RONDB_VERSION=21.04.13 \
   --build-arg RONDB_TARBALL_LOCAL_REMOTE=remote \  # alternatively "local"
-  --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-21.04.12-linux-glibc2.35-arm64_v8.tar.gz # alternatively a local file path
+  --build-arg RONDB_TARBALL_URI=https://repo.hops.works/master/rondb-21.04.13-linux-glibc2.35-arm64_v8.tar.gz # alternatively a local file path
 
 # Explore image
-docker run --rm -it --entrypoint=/bin/bash rondb-standalone:21.04.12
+docker run --rm -it --entrypoint=/bin/bash rondb-standalone:21.04.13
 ```
 
 Exemplatory commands to run with running docker-compose cluster:

--- a/sample_files/docker_compose.yml
+++ b/sample_files/docker_compose.yml
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
     mgmd_1:
-      image: rondb-standalone:21.04.12
+      image: rondb-standalone:21.04.13
       container_name: mgmd_1
       command: ["ndb_mgmd", "--ndb-nodeid=65", "--initial"]
       deploy:
@@ -28,7 +28,7 @@ services:
       - HOST_GROUP_ID=20
 
     ndbd_1:
-      image: rondb-standalone:21.04.12
+      image: rondb-standalone:21.04.13
       container_name: ndbd_1
       command: ["ndbmtd", "--ndb-nodeid=1", "--initial", "--ndb-connectstring=mgmd_1:1186"]
       healthcheck:
@@ -55,7 +55,7 @@ services:
       - HOST_GROUP_ID=20
 
     ndbd_2:
-      image: rondb-standalone:21.04.12
+      image: rondb-standalone:21.04.13
       container_name: ndbd_2
       command: ["ndbmtd", "--ndb-nodeid=2", "--initial", "--ndb-connectstring=mgmd_1:1186"]
       healthcheck:
@@ -82,7 +82,7 @@ services:
       - HOST_GROUP_ID=20
 
     mysqld_1:
-      image: rondb-standalone:21.04.12
+      image: rondb-standalone:21.04.13
       container_name: mysqld_1
       command: ["mysqld"]
       cap_add:
@@ -120,7 +120,7 @@ services:
       - MYSQL_SETUP_APP=1
 
     mysqld_2:
-      image: rondb-standalone:21.04.12
+      image: rondb-standalone:21.04.13
       container_name: mysqld_2
       command: ["mysqld"]
       cap_add:
@@ -157,7 +157,7 @@ services:
       - MYSQL_PASSWORD=Abc123?e
 
     rest_1:
-      image: rondb-standalone:21.04.12
+      image: rondb-standalone:21.04.13
       container_name: rest_1
       command: ["rdrs", "-config=/srv/hops/mysql-cluster/rest_api.json"]
       deploy:
@@ -185,7 +185,7 @@ services:
           condition: service_healthy
 
     bench_1:
-      image: rondb-standalone:21.04.12
+      image: rondb-standalone:21.04.13
       container_name: bench_1
       command: >
           bash -c "sleep 5 && bench_run.sh --verbose --default-directory /home/mysql/benchmarks/sysbench_multi "

--- a/sample_files/parsed_arguments.txt
+++ b/sample_files/parsed_arguments.txt
@@ -4,8 +4,8 @@ RonDB-Docker version: 0.3-SNAPSHOT
 Parsed arguments:
 #################
 
-RonDB version                 = 21.04.12
-RonDB tarball path            = ./rondb-21.04.12-linux-glibc2.35-arm64_v8.tar.gz
+RonDB version                 = 21.04.13
+RonDB tarball path            = ./rondb-21.04.13-linux-glibc2.35-arm64_v8.tar.gz
 RonDB tarball url             = 
 Number of management nodes    = 1
 Node groups                   = 1


### PR DESCRIPTION
This is needed to support the `--service` flag.